### PR TITLE
Fix issue #8:  Use corect careers URL

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -55,4 +55,4 @@ You can also financially support the project by contributing on [LocalStack's Op
 
 ## Join our team! 🤝
 
-We are looking for top-notch contributors to LocalStack. If you are interested in helping us become the world’s leading platform to support efficient dev & test loops for cloud applications, check out our [current open positions](https://localstack.cloud/jobs/). We can't wait to meet you!
+We are looking for top-notch contributors to LocalStack. If you are interested in helping us become the world’s leading platform to support efficient dev & test loops for cloud applications, check out our [current open positions]([https://localstack.cloud/jobs/](https://www.localstack.cloud/career-s)). We can't wait to meet you!

--- a/profile/README.md
+++ b/profile/README.md
@@ -55,4 +55,4 @@ You can also financially support the project by contributing on [LocalStack's Op
 
 ## Join our team! 🤝
 
-We are looking for top-notch contributors to LocalStack. If you are interested in helping us become the world’s leading platform to support efficient dev & test loops for cloud applications, check out our [current open positions]([https://localstack.cloud/jobs/](https://www.localstack.cloud/career-s)). We can't wait to meet you!
+We are looking for top-notch contributors to LocalStack. If you are interested in helping us become the world’s leading platform to support efficient dev & test loops for cloud applications, check out our [current open positions]([https://localstack.cloud/careers/](https://www.localstack.cloud/careers)). We can't wait to meet you!

--- a/profile/README.md
+++ b/profile/README.md
@@ -55,4 +55,4 @@ You can also financially support the project by contributing on [LocalStack's Op
 
 ## Join our team! 🤝
 
-We are looking for top-notch contributors to LocalStack. If you are interested in helping us become the world’s leading platform to support efficient dev & test loops for cloud applications, check out our [current open positions]([https://localstack.cloud/careers/](https://www.localstack.cloud/careers)). We can't wait to meet you!
+We are looking for top-notch contributors to LocalStack. If you are interested in helping us become the world’s leading platform to support efficient dev & test loops for cloud applications, check out our [current open positions](https://www.localstack.cloud/careers). We can't wait to meet you!


### PR DESCRIPTION
# What
- Fix of #8 
- Replaced an incorrect careers URL with the correct one.

## Updated Flow
Upon clicking the `current open positions` hyperlink, the user is now directed to the valid careers page.

![image](https://github.com/user-attachments/assets/428e224d-0e6e-4982-924d-8c57da2ace73)